### PR TITLE
mmap_get_rkey should call zhpe_tx_release

### DIFF
--- a/prov/zhpe/src/zhpe_fabric.c
+++ b/prov/zhpe/src/zhpe_fabric.c
@@ -199,10 +199,8 @@ static int mmap_get_rkey(struct fid_ep *ep, fi_addr_t fi_addr, uint64_t key,
 		ret = -FI_ENOKEY;
 
  done:
-	if (ret < 0) {
-		if (tindex != -1)
-			zhpe_tx_release(pe_entry);
-	}
+	if (tindex != -1)
+		zhpe_tx_release(pe_entry);
 
 	return ret;
 }


### PR DESCRIPTION
mmap_get_rkey calls zhpe_tx_reserve
When done, it should call zhpe_tx_release