### PR TITLE
Support new zhpe_stats library

### DIFF
--- a/prov/zhpe/src/zhpe_conn.c
+++ b/prov/zhpe/src/zhpe_conn.c
@@ -336,7 +336,9 @@ static void *_zhpe_conn_listen(void *arg)
 		rc = zhpe_send_blob(conn_fd, &action, sizeof(action));
 		if (rc < 0 || action != ZHPE_CONN_ACTION_NEW)
 			continue;
+		zhpe_stats_open(1000);
 		rc = zhpe_conn_z_setup(conn, conn_fd);
+		zhpe_stats_close();
 		if (rc >= 0)
 			zhpe_pe_signal(ep_attr->domain->pe);
 		else

--- a/prov/zhpe/src/zhpe_msg.c
+++ b/prov/zhpe/src/zhpe_msg.c
@@ -474,7 +474,7 @@ static ssize_t do_sendmsg(struct fid_ep *fid_ep, const void *vmsg,
 	*zhdr = hdr;
 	pe_entry->flags = flags;
 	zhpe_stats_stamp(zhpe_stats_subid(SEND, 35), (uintptr_t)pe_entry,
-			 pe_entry->rem, fiaddr, flags, hdr.flags);
+			 pe_entry->rem, fiaddr, flags, hdr.flags, 0);
 	zhpe_stats_start(zhpe_stats_subid(SEND, 40));
 	ret = zhpe_pe_tx_ring(pe_entry, zhdr, lzaddr, cmd_len);
 	zhpe_stats_stop(zhpe_stats_subid(SEND, 40));


### PR DESCRIPTION
zhpe_stats_stamp now expects 6 arguments.
zhpe_stats is now thread-local, so each thread must call zhpe_open